### PR TITLE
Add React landing page

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fremen AI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap" rel="stylesheet">
+  <style>
+    body {
+      font-family: 'Inter', sans-serif;
+      margin: 0;
+      padding: 0;
+      line-height: 1.4;
+      background-color: #0e1017;
+      color: #fff;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+    header, footer {
+      padding: 2rem;
+      text-align: center;
+    }
+    section {
+      padding: 2rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+    }
+    .cta-container {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      justify-content: center;
+    }
+    .cta-box {
+      border: 1px solid #4caf50;
+      background-color: #1d1f29;
+      padding: 1.5rem;
+      border-radius: 8px;
+      width: 280px;
+    }
+    .cta-box h3 {
+      margin-top: 0;
+      margin-bottom: 1rem;
+    }
+    button {
+      background-color: #4caf50;
+      border: none;
+      color: #fff;
+      padding: 0.5rem 1rem;
+      cursor: pointer;
+      font-size: 1rem;
+      border-radius: 4px;
+    }
+    .flow-container {
+      width: 100%;
+      height: 400px;
+      margin-top: 2rem;
+    }
+    @media (min-width: 600px) {
+      section {
+        padding: 4rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/reactflow/dist/react-flow.min.js"></script>
+
+  <script type="text/babel">
+    const { ReactFlow, MiniMap, Controls, Background } = window.ReactFlow;
+
+    function App() {
+      const nodes = [
+        { id: '1', position: { x: 50, y: 5 }, data: { label: 'Desktop' } },
+        { id: '2', position: { x: 200, y: 5 }, data: { label: 'Web' } },
+        { id: '3', position: { x: 350, y: 5 }, data: { label: 'Mobile' } }
+      ];
+      const edges = [
+        { id: 'e1-2', source: '1', target: '2' },
+        { id: 'e2-3', source: '2', target: '3' }
+      ];
+
+      return (
+        <div>
+          <header>
+            <h1>Fremen AI Agents</h1>
+            <p>Stable desktop, web & mobile automation</p>
+          </header>
+
+          <section>
+            <h2>Technologies</h2>
+            <p>We use the latest technologies n8n, langchain and langflow in addition to the latest reinforcement learning techniques like GRPO to automate your work.</p>
+            <div className="flow-container">
+              <ReactFlow nodes={nodes} edges={edges} fitView>
+                <MiniMap />
+                <Controls />
+                <Background variant="dots" gap={12} size={1} />
+              </ReactFlow>
+            </div>
+          </section>
+
+          <section className="cta-container">
+            <div className="cta-box">
+              <h3>Request a Demo</h3>
+              <button onClick={() => alert('We will reach out soon!')}>Contact Us</button>
+            </div>
+            <div className="cta-box">
+              <h3>Get on the Waitlist</h3>
+              <button onClick={() => alert('Added to waitlist!')}>Join Now</button>
+            </div>
+          </section>
+
+          <section>
+            <p>Answer a short questionnaire and discover how Fremen AI can turn you into a paid customer.</p>
+          </section>
+
+          <footer>
+            &copy; 2024 Fremen AI
+          </footer>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create minimal futuristic landing page using React and React Flow
- include demo and waitlist call to action sections

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6848abcf024483299aecc19fac4f946e